### PR TITLE
dev/core#1142 Change Edge profile in master to use MySQL8 rather than MySQL5.7 and …

### DIFF
--- a/pins/19.09.nix
+++ b/pins/19.09.nix
@@ -1,0 +1,5 @@
+## Track latest iteration of 19.09.
+# fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.09.tar.gz
+
+## Use a specific 19.09 iteration.
+fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/d5291756487d70bc336e33512a9baf9fa1788faf.tar.gz

--- a/profiles/edge/default.nix
+++ b/profiles/edge/default.nix
@@ -5,7 +5,7 @@
  */
 let
     pkgs = import (import ../../pins/18.09.nix) {};
-    mpkgs = import (import ../../pins/19.09.nix) {};
+    pkgs_1909 = import (import ../../pins/19.09.nix) {};
     bkpkgs = import ../../pkgs;
 in [
     /* Custom programs */
@@ -16,7 +16,7 @@ in [
     pkgs.nodejs-8_x
     pkgs.apacheHttpd
     pkgs.memcached
-    mpkgs.mysql80
+    pkgs_1909.mysql80
     pkgs.redis
 
     /* CLI utilities */

--- a/profiles/edge/default.nix
+++ b/profiles/edge/default.nix
@@ -5,6 +5,7 @@
  */
 let
     pkgs = import (import ../../pins/18.09.nix) {};
+    mpkgs = import (import ../../pins/19.09.nix) {};
     bkpkgs = import ../../pkgs;
 in [
     /* Custom programs */
@@ -15,7 +16,7 @@ in [
     pkgs.nodejs-8_x
     pkgs.apacheHttpd
     pkgs.memcached
-    pkgs.mysql57
+    mpkgs.mysql80
     pkgs.redis
 
     /* CLI utilities */


### PR DESCRIPTION
…use the upstream package version

This updates the edge profile to use MySQL8 from the NixOS repos now that your PR has been merged in upstream. In the current master version i don't see any reference to the 
`query_cache_size` variable at all but maybe that is differently