### PR TITLE
Update to use upstream MySQL 8 version and set default authentication…

### DIFF
--- a/.loco/bin/loco-mysql-init
+++ b/.loco/bin/loco-mysql-init
@@ -4,7 +4,7 @@
 
 mkdir "$LOCO_SVC_VAR"/{log,tmp,run}
 
-php "$LOCO_SVC_CFG"/conf/common-my.cnf.php > "$LOCO_SVC_VAR"/conf/common-my.cnf
+php "$LOCO_CFG/mysql-common/my.cnf.php" > "$LOCO_SVC_VAR"/conf/common-my.cnf
 
 ## MySQL v5.7
 if mysql --version | grep 'Distrib 5.7' -q; then

--- a/.loco/config/mysql-common/my.cnf.php
+++ b/.loco/config/mysql-common/my.cnf.php
@@ -17,7 +17,7 @@ read_rnd_buffer_size = 4M
 myisam_sort_buffer_size = 64M
 thread_cache_size = 8
 <?php if (!matchVer('/Ver 8.0/')) { ?>query_cache_size= 16M<?php } ?>
-
+<?php if (matchVer('/Ver 8.0/')) { ?>default_authentication_plugin = mysql_native_password<?php } ?>
 # Try number of CPU's*2 for thread_concurrency
 #MariaDB?# thread_concurrency = 8
 

--- a/.loco/config/mysql/conf/my.cnf.loco.tpl
+++ b/.loco/config/mysql/conf/my.cnf.loco.tpl
@@ -1,4 +1,4 @@
-!include {{LOCO_CFG}}/mysql/my.cnf
+!include {{LOCO_SVC_VAR}}/conf/common-my.cnf
 
 [client]
 user		= root

--- a/pins/19.09.nix
+++ b/pins/19.09.nix
@@ -1,0 +1,5 @@
+## Track latest iteration of 19.09.
+# fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.09.tar.gz
+
+## Use a specific 19.09 iteration.
+fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/d5291756487d70bc336e33512a9baf9fa1788faf.tar.gz

--- a/pins/nixpkgs-pr-mysql80.nix
+++ b/pins/nixpkgs-pr-mysql80.nix
@@ -1,4 +1,0 @@
-## Temporary branch of nixpkgs@master to add mysql80.
-## Remove this once there's an official mysql80 pkg.
-## See: https://github.com/NixOS/nixpkgs/pull/65221
-fetchTarball https://github.com/totten/nixpkgs/archive/mysql80.tar.gz

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -14,7 +14,6 @@ let
 
 in rec {
    mysql55 = (import ./mysql55/default.nix).mysql55;
-   mysql80 = (import (import ../pins/nixpkgs-pr-mysql80.nix) {}).mysql80;
    php56 = import ./php56/default.nix;
    php70 = import ./php70/default.nix;
    ## Not used, don't waste any build-time on it ## php71 = import ./php71/default.nix;

--- a/profiles/edge/default.nix
+++ b/profiles/edge/default.nix
@@ -5,6 +5,7 @@
  */
 let
     pkgs = import (import ../../pins/18.09.nix) {};
+    pkgs_1909 = import (import ../../pins/19.09.nix) {};
     bkpkgs = import ../../pkgs;
 in [
     /* Custom programs */
@@ -18,7 +19,7 @@ in [
     pkgs.mailcatcher
     pkgs.memcached
     /* pkgs.mariadb */
-    bkpkgs.mysql80
+    pkgs_1909.mysql80
     pkgs.redis
 
     /* CLI utilities */


### PR DESCRIPTION
… plugin to be mysql_native_password for MySQL 8

@totten this just switches the loco branch to the upstream version and setting the default authentication plugin to be mysql_native_password 