### PR TITLE
(master-loco) Extract `base` profile. Fix glibcLocales on Linux.

### DIFF
--- a/profiles/base/default.nix
+++ b/profiles/base/default.nix
@@ -1,0 +1,21 @@
+/**
+ * The `base` profile defines a series of common CLI utilities that rarely change.
+ */
+let
+    pkgs = import (import ../../pins/19.09.nix) {};
+in [
+    pkgs.bzip2
+    pkgs.curl
+    pkgs.gettext
+    pkgs.git
+    pkgs.gitAndTools.hub
+    pkgs.gnugrep
+    pkgs.gnutar
+    pkgs.hostname
+    pkgs.ncurses
+    pkgs.patch
+    pkgs.rsync
+    pkgs.unzip
+    pkgs.which
+    pkgs.zip
+] ++ (if pkgs.glibcLocales != null then [pkgs.glibcLocales] else [] )

--- a/profiles/default.nix
+++ b/profiles/default.nix
@@ -5,6 +5,11 @@
  */
 rec {
    /**
+    * Common base shared by all other profiles
+    */
+   base = import ./base/default.nix;
+
+   /**
     * The minimum system requirements.
     */
    min = import ./min/default.nix;

--- a/profiles/dfl/default.nix
+++ b/profiles/dfl/default.nix
@@ -8,7 +8,8 @@ let
     pkgs = import (import ../../pins/19.09.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-in [
+    base = import ../base/default.nix;
+in base ++ [
     /* Custom programs */
     bkpkgs.launcher
     bkpkgs.bknixPhpstormAdvisor
@@ -25,19 +26,5 @@ in [
     /* CLI utilities */
     bkpkgs.loco
     bkpkgs.ramdisk
-    pkgs.bzip2
-    pkgs.curl
-    pkgs.gettext
-    pkgs.git
-    pkgs.gitAndTools.hub
-    pkgs.gnugrep
-    pkgs.gnutar
-    pkgs.hostname
-    pkgs.ncurses
-    pkgs.patch
-    pkgs.rsync
-    pkgs.unzip
-    pkgs.which
-    pkgs.zip
     bkpkgs.transifexClient
 ]

--- a/profiles/edge/default.nix
+++ b/profiles/edge/default.nix
@@ -8,7 +8,8 @@ let
     pkgs = import (import ../../pins/19.09.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-in [
+    base = import ../base/default.nix;
+in base ++ [
     /* Custom programs */
     bkpkgs.launcher
     bkpkgs.bknixPhpstormAdvisor
@@ -26,19 +27,5 @@ in [
     /* CLI utilities */
     bkpkgs.loco
     bkpkgs.ramdisk
-    pkgs.bzip2
-    pkgs.curl
-    pkgs.gettext
-    pkgs.git
-    pkgs.gitAndTools.hub
-    pkgs.gnugrep
-    pkgs.gnutar
-    pkgs.hostname
-    pkgs.ncurses
-    pkgs.patch
-    pkgs.rsync
-    pkgs.unzip
-    pkgs.which
-    pkgs.zip
     bkpkgs.transifexClient
 ]

--- a/profiles/max/default.nix
+++ b/profiles/max/default.nix
@@ -8,7 +8,8 @@ let
     pkgs = import (import ../../pins/19.09.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-in [
+    base = import ../base/default.nix;
+in base ++ [
     /* Custom programs */
     bkpkgs.launcher
     bkpkgs.bknixPhpstormAdvisor
@@ -25,19 +26,5 @@ in [
     /* CLI utilities */
     bkpkgs.loco
     bkpkgs.ramdisk
-    pkgs.bzip2
-    pkgs.curl
-    pkgs.gettext
-    pkgs.git
-    pkgs.gitAndTools.hub
-    pkgs.gnugrep
-    pkgs.gnutar
-    pkgs.hostname
-    pkgs.ncurses
-    pkgs.patch
-    pkgs.rsync
-    pkgs.unzip
-    pkgs.which
-    pkgs.zip
     bkpkgs.transifexClient
 ]

--- a/profiles/min/default.nix
+++ b/profiles/min/default.nix
@@ -8,7 +8,8 @@ let
     pkgs = import (import ../../pins/19.09.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-in [
+    base = import ../base/default.nix;
+in base ++ [
     /* Custom programs */
     bkpkgs.launcher
     bkpkgs.bknixPhpstormAdvisor
@@ -25,19 +26,5 @@ in [
     /* CLI utilities */
     bkpkgs.loco
     bkpkgs.ramdisk
-    pkgs.bzip2
-    pkgs.curl
-    pkgs.gettext
-    pkgs.git
-    pkgs.gitAndTools.hub
-    pkgs.gnugrep
-    pkgs.gnutar
-    pkgs.hostname
-    pkgs.ncurses
-    pkgs.patch
-    pkgs.rsync
-    pkgs.unzip
-    pkgs.which
-    pkgs.zip
     bkpkgs.transifexClient
 ]

--- a/profiles/old/default.nix
+++ b/profiles/old/default.nix
@@ -7,7 +7,8 @@ let
     pkgs = import (import ../../pins/18.03.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-in [
+    base = import ../base/default.nix;
+in base ++ [
     /* Custom programs */
     bkpkgs.launcher
     bkpkgs.bknixPhpstormAdvisor
@@ -24,19 +25,5 @@ in [
     /* CLI utilities */
     bkpkgs.loco
     bkpkgs.ramdisk
-    pkgs.bzip2
-    pkgs.curl
-    pkgs.gettext
-    pkgs.git
-    pkgs.gitAndTools.hub
-    pkgs.gnugrep
-    pkgs.gnutar
-    pkgs_1809.hostname
-    pkgs_1809.ncurses
-    pkgs.patch
-    pkgs.rsync
-    pkgs.unzip
-    pkgs.which
-    pkgs.zip
     bkpkgs.transifexClient
 ]


### PR DESCRIPTION
To test, I ran this command line on Linux and OSX:

```
for P in old min dfl max edge ; do nix-shell -A $P --run 'echo; git --version; php --version; php /tmp/y.php' ; done
```

Where `/tmp/y.php` is a script that runs `money_format()` in a couple different locales:

```
<?php
$valueFormat = '%!i';
$amount = 1234567.8901;
foreach (['fr_FR', 'en_US.utf8', 'en_US', 'C'] as $ltest) {
  $lc = setlocale(LC_MONETARY, 0);
  setlocale(LC_MONETARY, $ltest, 'C');
  printf("%15s: %s\n", $ltest, money_format($valueFormat, $amount));
  setlocale(LC_MONETARY, $lc);
}
```

There seem some differences in which locales are supported on my Linux and OSX builds, but the basic mechanism of `money_format()` does seem to work in each case.