### PR TITLE
Extract `base` and `mgmt` profiles. Updates for nixpkgs 19.09

### DIFF
--- a/profiles/base/default.nix
+++ b/profiles/base/default.nix
@@ -1,0 +1,21 @@
+/**
+ * The `base` profile defines a series of common CLI utilities that rarely change.
+ */
+let
+    pkgs = import (import ../../pins/19.09.nix) {};
+in [
+    pkgs.bzip2
+    pkgs.curl
+    pkgs.gettext
+    pkgs.git
+    pkgs.gitAndTools.hub
+    pkgs.gnugrep
+    pkgs.gnutar
+    pkgs.hostname
+    pkgs.ncurses
+    pkgs.patch
+    pkgs.rsync
+    pkgs.unzip
+    pkgs.which
+    pkgs.zip
+] ++ (if pkgs.glibcLocales != null then [pkgs.glibcLocales] else [] )

--- a/profiles/default.nix
+++ b/profiles/default.nix
@@ -4,10 +4,20 @@
  * list of packages that can be installed in (one of) your profile(s).
  */
 rec {
+
+   /* ---------- Partial profiles; building-blocks ---------- */
+
    /**
-    * Common base shared by all other profiles
+    * Common CLI utilities shared by all other profiles
     */
    base = import ./base/default.nix;
+
+   /**
+    * bknix-specific management utilities
+    */
+   mgmt = import ./mgmt/default.nix;
+
+   /* ---------- Full profiles ---------- */
 
    /**
     * The minimum system requirements.

--- a/profiles/default.nix
+++ b/profiles/default.nix
@@ -5,6 +5,11 @@
  */
 rec {
    /**
+    * Common base shared by all other profiles
+    */
+   base = import ./base/default.nix;
+
+   /**
     * The minimum system requirements.
     */
    min = import ./min/default.nix;

--- a/profiles/dfl/default.nix
+++ b/profiles/dfl/default.nix
@@ -8,7 +8,8 @@ let
     pkgs = import (import ../../pins/18.03.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-in [
+    base = import ../base/default.nix;
+in base ++ [
     /* Custom programs */
     bkpkgs.launcher
 
@@ -21,18 +22,5 @@ in [
     pkgs.redis
 
     /* CLI utilities */
-    pkgs.bzip2
-    pkgs.curl
-    pkgs.git
-    pkgs.gitAndTools.hub
-    pkgs.gnugrep
-    pkgs.gnutar
-    pkgs_1809.hostname
-    pkgs_1809.ncurses
-    pkgs.patch
-    pkgs.rsync
-    pkgs.unzip
-    pkgs.which
-    pkgs.zip
     bkpkgs.transifexClient
 ]

--- a/profiles/dfl/default.nix
+++ b/profiles/dfl/default.nix
@@ -8,19 +8,15 @@ let
     pkgs = import (import ../../pins/18.03.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-    baseProfile = import ../base/default.nix;
-in baseProfile ++ [
-    /* Custom programs */
-    bkpkgs.launcher
 
-    /* Major services */
+in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
+
     bkpkgs.php71
     pkgs.nodejs-8_x
     pkgs.apacheHttpd
     pkgs.memcached
     pkgs_1809.mysql57
     pkgs.redis
-
-    /* CLI utilities */
     bkpkgs.transifexClient
+
 ]

--- a/profiles/dfl/default.nix
+++ b/profiles/dfl/default.nix
@@ -1,19 +1,20 @@
 /**
  * The `dfl` list identifies the lowest recommended versions of the system requirements.
  *
- * We rely on a mix of packages from Nix upstream v18.03 (`pkgs`), v18.09 (`pkgs_1809`), and
+ * We rely on a mix of packages from Nix upstream v19.09 (`pkgs`), v18.09 (`pkgs_1809`), and
  * custom forks (`bkpkgs`).
  */
 let
-    pkgs = import (import ../../pins/18.03.nix) {};
+    pkgs = import (import ../../pins/19.09.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
     bkpkgs.php71
-    pkgs.nodejs-8_x
+    pkgs_1809.nodejs-8_x
     pkgs.apacheHttpd
+    /* pkgs_1809.mailcatcher */
     pkgs.memcached
     pkgs_1809.mysql57
     pkgs.redis

--- a/profiles/dfl/default.nix
+++ b/profiles/dfl/default.nix
@@ -8,8 +8,8 @@ let
     pkgs = import (import ../../pins/18.03.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-    base = import ../base/default.nix;
-in base ++ [
+    baseProfile = import ../base/default.nix;
+in baseProfile ++ [
     /* Custom programs */
     bkpkgs.launcher
 

--- a/profiles/edge/default.nix
+++ b/profiles/edge/default.nix
@@ -7,7 +7,8 @@ let
     pkgs = import (import ../../pins/18.09.nix) {};
     pkgs_1909 = import (import ../../pins/19.09.nix) {};
     bkpkgs = import ../../pkgs;
-in [
+    base = import ../base/default.nix;
+in base ++ [
     /* Custom programs */
     bkpkgs.launcher
 
@@ -20,18 +21,5 @@ in [
     pkgs.redis
 
     /* CLI utilities */
-    pkgs.bzip2
-    pkgs.curl
-    pkgs.git
-    pkgs.gitAndTools.hub
-    pkgs.gnugrep
-    pkgs.gnutar
-    pkgs.hostname
-    pkgs.ncurses
-    pkgs.patch
-    pkgs.rsync
-    pkgs.unzip
-    pkgs.which
-    pkgs.zip
     bkpkgs.transifexClient
 ]

--- a/profiles/edge/default.nix
+++ b/profiles/edge/default.nix
@@ -7,8 +7,8 @@ let
     pkgs = import (import ../../pins/18.09.nix) {};
     pkgs_1909 = import (import ../../pins/19.09.nix) {};
     bkpkgs = import ../../pkgs;
-    base = import ../base/default.nix;
-in base ++ [
+    baseProfile = import ../base/default.nix;
+in baseProfile ++ [
     /* Custom programs */
     bkpkgs.launcher
 

--- a/profiles/edge/default.nix
+++ b/profiles/edge/default.nix
@@ -1,20 +1,23 @@
 /**
  * The `max` list identifies the highest recommended versions of the system requirements.
  *
- * We rely on a mix of packages from Nix upstream v18.09 (`pkgs`) and custom forks (`bkpkgs`).
+ * We rely on a mix of packages from Nix upstream v19.09 (`pkgs`), v18.09 (`pkgs_1809`), and
+ * custom forks (`bkpkgs`).
  */
 let
-    pkgs = import (import ../../pins/18.09.nix) {};
-    pkgs_1909 = import (import ../../pins/19.09.nix) {};
+    pkgs = import (import ../../pins/19.09.nix) {};
+    pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
     bkpkgs.php73
-    pkgs.nodejs-8_x
+    pkgs_1809.nodejs-8_x
     pkgs.apacheHttpd
+    /* pkgs_1809.mailcatcher */
     pkgs.memcached
-    pkgs_1909.mysql80
+    /* pkgs.mariadb */
+    pkgs.mysql80
     pkgs.redis
     bkpkgs.transifexClient
 

--- a/profiles/edge/default.nix
+++ b/profiles/edge/default.nix
@@ -7,19 +7,15 @@ let
     pkgs = import (import ../../pins/18.09.nix) {};
     pkgs_1909 = import (import ../../pins/19.09.nix) {};
     bkpkgs = import ../../pkgs;
-    baseProfile = import ../base/default.nix;
-in baseProfile ++ [
-    /* Custom programs */
-    bkpkgs.launcher
 
-    /* Major services */
+in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
+
     bkpkgs.php73
     pkgs.nodejs-8_x
     pkgs.apacheHttpd
     pkgs.memcached
     pkgs_1909.mysql80
     pkgs.redis
-
-    /* CLI utilities */
     bkpkgs.transifexClient
+
 ]

--- a/profiles/max/default.nix
+++ b/profiles/max/default.nix
@@ -6,8 +6,8 @@
 let
     pkgs = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-    base = import ../base/default.nix;
-in base ++ [
+    baseProfile = import ../base/default.nix;
+in baseProfile ++ [
     /* Custom programs */
     bkpkgs.launcher
 

--- a/profiles/max/default.nix
+++ b/profiles/max/default.nix
@@ -6,7 +6,8 @@
 let
     pkgs = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-in [
+    base = import ../base/default.nix;
+in base ++ [
     /* Custom programs */
     bkpkgs.launcher
 
@@ -19,18 +20,5 @@ in [
     pkgs.redis
 
     /* CLI utilities */
-    pkgs.bzip2
-    pkgs.curl
-    pkgs.git
-    pkgs.gitAndTools.hub
-    pkgs.gnugrep
-    pkgs.gnutar
-    pkgs.hostname
-    pkgs.ncurses
-    pkgs.patch
-    pkgs.rsync
-    pkgs.unzip
-    pkgs.which
-    pkgs.zip
     bkpkgs.transifexClient
 ]

--- a/profiles/max/default.nix
+++ b/profiles/max/default.nix
@@ -6,19 +6,15 @@
 let
     pkgs = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-    baseProfile = import ../base/default.nix;
-in baseProfile ++ [
-    /* Custom programs */
-    bkpkgs.launcher
 
-    /* Major services */
+in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
+
     bkpkgs.php72
     pkgs.nodejs-8_x
     pkgs.apacheHttpd
     pkgs.memcached
     pkgs.mysql57
     pkgs.redis
-
-    /* CLI utilities */
     bkpkgs.transifexClient
+
 ]

--- a/profiles/max/default.nix
+++ b/profiles/max/default.nix
@@ -1,17 +1,20 @@
 /**
  * The `max` list identifies the highest recommended versions of the system requirements.
  *
- * We rely on a mix of packages from Nix upstream v18.09 (`pkgs`) and custom forks (`bkpkgs`).
+ * We rely on a mix of packages from Nix upstream v19.09 (`pkgs`), v18.09 (`pkgs_1809`), and
+ * custom forks (`bkpkgs`).
  */
 let
-    pkgs = import (import ../../pins/18.09.nix) {};
+    pkgs = import (import ../../pins/19.09.nix) {};
+    pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
     bkpkgs.php72
-    pkgs.nodejs-8_x
+    pkgs_1809.nodejs-8_x
     pkgs.apacheHttpd
+    /* pkgs_1809.mailcatcher */
     pkgs.memcached
     pkgs.mysql57
     pkgs.redis

--- a/profiles/mgmt/default.nix
+++ b/profiles/mgmt/default.nix
@@ -1,0 +1,16 @@
+/**
+ * The `mgmt` profile provides bknix's process management utilities for
+ * starting/stopping daemons.
+ *
+ * At time of writing, this profile represents the main difference between
+ * the branches `master` and `master-loco`
+ */
+let
+    pkgs = import (import ../../pins/19.09.nix) {};
+    bkpkgs = import ../../pkgs;
+in [
+    bkpkgs.launcher
+    # bkpkgs.bknixPhpstormAdvisor
+    # bkpkgs.loco
+    # bkpkgs.ramdisk
+]

--- a/profiles/min/default.nix
+++ b/profiles/min/default.nix
@@ -1,18 +1,20 @@
 /**
  * The `min` list identifies the lowest recommended versions of the system requirements.
  *
- * We rely on a mix of packages from Nix upstream v18.03 (`pkgs`) and custom forks (`bkpkgs`).
+ * We rely on a mix of packages from Nix upstream v19.09 (`pkgs`), v18.09 (`pkgs_1809`), and
+ * custom forks (`bkpkgs`).
  */
 let
-    pkgs = import (import ../../pins/18.03.nix) {};
+    pkgs = import (import ../../pins/19.09.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
 
 in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
     bkpkgs.php70
-    pkgs.nodejs-8_x
+    pkgs_1809.nodejs-8_x
     pkgs.apacheHttpd
+    pkgs_1809.mailcatcher
     pkgs.memcached
     bkpkgs.mysql55
     pkgs.redis

--- a/profiles/min/default.nix
+++ b/profiles/min/default.nix
@@ -7,19 +7,15 @@ let
     pkgs = import (import ../../pins/18.03.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-    baseProfile = import ../base/default.nix;
-in baseProfile ++ [
-    /* Custom programs */
-    bkpkgs.launcher
 
-    /* Major services */
+in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
+
     bkpkgs.php70
     pkgs.nodejs-8_x
     pkgs.apacheHttpd
     pkgs.memcached
     bkpkgs.mysql55
     pkgs.redis
-
-    /* CLI utilities */
     bkpkgs.transifexClient
+
 ]

--- a/profiles/min/default.nix
+++ b/profiles/min/default.nix
@@ -7,7 +7,8 @@ let
     pkgs = import (import ../../pins/18.03.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-in [
+    base = import ../base/default.nix;
+in base ++ [
     /* Custom programs */
     bkpkgs.launcher
 
@@ -20,18 +21,5 @@ in [
     pkgs.redis
 
     /* CLI utilities */
-    pkgs.bzip2
-    pkgs.curl
-    pkgs.git
-    pkgs.gitAndTools.hub
-    pkgs.gnugrep
-    pkgs.gnutar
-    pkgs_1809.hostname
-    pkgs_1809.ncurses
-    pkgs.patch
-    pkgs.rsync
-    pkgs.unzip
-    pkgs.which
-    pkgs.zip
     bkpkgs.transifexClient
 ]

--- a/profiles/min/default.nix
+++ b/profiles/min/default.nix
@@ -7,8 +7,8 @@ let
     pkgs = import (import ../../pins/18.03.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-    base = import ../base/default.nix;
-in base ++ [
+    baseProfile = import ../base/default.nix;
+in baseProfile ++ [
     /* Custom programs */
     bkpkgs.launcher
 

--- a/profiles/old/default.nix
+++ b/profiles/old/default.nix
@@ -7,19 +7,14 @@ let
     pkgs = import (import ../../pins/18.03.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-    baseProfile = import ../base/default.nix;
-in baseProfile ++ [
-    /* Custom programs */
-    bkpkgs.launcher
+in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
 
-    /* Major services */
     bkpkgs.php56
     pkgs.nodejs-8_x
     pkgs.apacheHttpd
     pkgs.memcached
     bkpkgs.mysql55
     pkgs.redis
-
-    /* CLI utilities */
     bkpkgs.transifexClient
+
 ]

--- a/profiles/old/default.nix
+++ b/profiles/old/default.nix
@@ -7,7 +7,8 @@ let
     pkgs = import (import ../../pins/18.03.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-in [
+    base = import ../base/default.nix;
+in base ++ [
     /* Custom programs */
     bkpkgs.launcher
 
@@ -20,18 +21,5 @@ in [
     pkgs.redis
 
     /* CLI utilities */
-    pkgs.bzip2
-    pkgs.curl
-    pkgs.git
-    pkgs.gitAndTools.hub
-    pkgs.gnugrep
-    pkgs.gnutar
-    pkgs_1809.hostname
-    pkgs_1809.ncurses
-    pkgs.patch
-    pkgs.rsync
-    pkgs.unzip
-    pkgs.which
-    pkgs.zip
     bkpkgs.transifexClient
 ]

--- a/profiles/old/default.nix
+++ b/profiles/old/default.nix
@@ -7,8 +7,8 @@ let
     pkgs = import (import ../../pins/18.03.nix) {};
     pkgs_1809 = import (import ../../pins/18.09.nix) {};
     bkpkgs = import ../../pkgs;
-    base = import ../base/default.nix;
-in base ++ [
+    baseProfile = import ../base/default.nix;
+in baseProfile ++ [
     /* Custom programs */
     bkpkgs.launcher
 


### PR DESCRIPTION
Updates to match recent changes in `master-loco`

* Extract common elements from the profiles into partial/sub-profiles named `base` and `mgmt`
* As Seamus discovered, newer versions of nix (*on Linux*) require `glibcLocales` in order to pass the Civi unit tests. https://chat.civicrm.org/civicrm/pl/hgburo6nabf8pmar4wotg83jmo 
* This also does general updates from 18.03 to 19.09 on various packages for which we're not too particular.

With this update, the `profiles` in `master` and `master-loco` are pretty close together again. The main differences are in `mgmt` (e.g. usage of `loco`) and in `mailcatcher` (which is commented out in `master`).