### PR TITLE
(master-loco) Define mysql56 package

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -14,6 +14,7 @@ let
 
 in rec {
    mysql55 = (import ./mysql55/default.nix).mysql55;
+   mysql56 = (import ./mysql56/default.nix).mysql56;
    php56 = import ./php56/default.nix;
    php70 = import ./php70/default.nix;
    php71 = import ./php71/default.nix;

--- a/pkgs/mysql56/5.6.x.nix
+++ b/pkgs/mysql56/5.6.x.nix
@@ -23,8 +23,8 @@ self = stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake bison pkgconfig ];
 
-  buildInputs = [ boost libedit libevent lz4 ncurses openssl protobuf readline zlib ]
-     ++ stdenv.lib.optionals stdenv.isDarwin [ perl cctools CoreServices developer_cmds ];
+  buildInputs = [ boost libedit libevent lz4 ncurses openssl perl protobuf readline zlib ]
+     ++ stdenv.lib.optionals stdenv.isDarwin [ cctools CoreServices developer_cmds ];
 
   outputs = [ "out" "static" ];
 
@@ -66,7 +66,6 @@ self = stdenv.mkDerivation rec {
   '';
   postInstall = ''
     moveToOutput "lib/*.a" $static
-#    ln -s libmysqlclient${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/libmysqlclient_r${stdenv.hostPlatform.extensions.sharedLibrary}
   '';
 
   passthru = {

--- a/pkgs/mysql56/5.6.x.nix
+++ b/pkgs/mysql56/5.6.x.nix
@@ -1,0 +1,88 @@
+{ stdenv, fetchurl, cmake, bison, pkgconfig
+, boost, libedit, libevent, lz4, ncurses, openssl, protobuf, readline, zlib, perl
+, cctools, CoreServices, developer_cmds }:
+
+# Note: zlib is not required; MySQL can use an internal zlib.
+
+let
+self = stdenv.mkDerivation rec {
+  pname = "mysql";
+  version = "5.6.47";
+
+  src = fetchurl {
+#    url = "mirror://mysql/MySQL-5.7/${pname}-${version}.tar.gz";
+#    sha256 = "1fhv16zr46pxm1j8vb8x8mh3nwzglg01arz8gnazbmjqldr5idpq";
+    url = "https://dev.mysql.com/get/Downloads/MySQL-5.6/${pname}-${version}.tar.gz";
+    sha256 = "sha256:1zi7j4m78a37jrjqqz4nfvfkw225jglhgdhvhfpn4k3q0mkhj689";
+  };
+
+  preConfigure = stdenv.lib.optional stdenv.isDarwin ''
+    ln -s /bin/ps $TMPDIR/ps
+    export PATH=$PATH:$TMPDIR
+  '';
+
+  nativeBuildInputs = [ cmake bison pkgconfig ];
+
+  buildInputs = [ boost libedit libevent lz4 ncurses openssl protobuf readline zlib ]
+     ++ stdenv.lib.optionals stdenv.isDarwin [ perl cctools CoreServices developer_cmds ];
+
+  outputs = [ "out" "static" ];
+
+  cmakeFlags = [
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # To run libmysql/libmysql_api_test during build.
+    "-DWITH_SSL=yes"
+    "-DWITH_EMBEDDED_SERVER=yes"
+    "-DWITH_UNIT_TESTS=no"
+    "-DWITH_EDITLINE=system"
+    "-DWITH_LIBEVENT=system"
+    "-DWITH_LZ4=system"
+    "-DWITH_PROTOBUF=system"
+    "-DWITH_ZLIB=system"
+    "-DWITH_ARCHIVE_STORAGE_ENGINE=yes"
+    "-DWITH_BLACKHOLE_STORAGE_ENGINE=yes"
+    "-DWITH_FEDERATED_STORAGE_ENGINE=yes"
+    "-DHAVE_IPV6=yes"
+    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+    "-DMYSQL_DATADIR=/var/lib/mysql"
+    "-DINSTALL_INFODIR=share/mysql/docs"
+    "-DINSTALL_MANDIR=share/man"
+    "-DINSTALL_PLUGINDIR=lib/mysql/plugin"
+    "-DINSTALL_SCRIPTDIR=bin"
+    "-DINSTALL_INCLUDEDIR=include/mysql"
+    "-DINSTALL_DOCREADMEDIR=share/mysql"
+    "-DINSTALL_SUPPORTFILESDIR=share/mysql"
+    "-DINSTALL_MYSQLSHAREDIR=share/mysql"
+    "-DINSTALL_MYSQLTESTDIR="
+    "-DINSTALL_DOCDIR=share/mysql/docs"
+    "-DINSTALL_SHAREDIR=share/mysql"
+  ];
+
+  CXXFLAGS = "-fpermissive -std=c++11";
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
+
+  prePatch = ''
+    # sed -i -e "s|/usr/bin/libtool|libtool|" cmake/merge_archives.cmake.in
+    sed -i -e "s|/usr/bin/libtool|libtool|" cmake/libutils.cmake
+  '';
+  postInstall = ''
+    moveToOutput "lib/*.a" $static
+#    ln -s libmysqlclient${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/libmysqlclient_r${stdenv.hostPlatform.extensions.sharedLibrary}
+  '';
+
+  passthru = {
+    client = self;
+    connector-c = self;
+    server = self;
+    mysqlVersion = "5.6";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.mysql.com/";
+    description = "The world's most popular open source database";
+    platforms = platforms.unix;
+    license = with licenses; [
+      artistic1 bsd0 bsd2 bsd3 bsdOriginal
+      gpl2 lgpl2 lgpl21 mit publicDomain licenses.zlib
+    ];
+  };
+}; in self

--- a/pkgs/mysql56/default.nix
+++ b/pkgs/mysql56/default.nix
@@ -1,0 +1,19 @@
+/**
+ * This builds mysql56. This version has never been published in nixpkgs. 
+ * It's derived from a recent mysql57 build script.
+ */
+let
+#  nixpkgs = import (import ../../pins/18.03.nix) {};
+  nixpkgs = import (import ../../pins/19.09.nix) {};
+  allPkgs = nixpkgs // pkgs;
+  callPackage = path: overrides:
+    let f = import path;
+    in f ((builtins.intersectAttrs (builtins.functionArgs f) allPkgs) // overrides);
+  pkgs = with nixpkgs; {
+    mysql56 = callPackage ./5.6.x.nix {
+      inherit (darwin) cctools developer_cmds;
+      inherit (darwin.apple_sdk.frameworks) CoreServices;
+      # boost = boost169; # Configure checks for specific version.
+    };
+  };
+in pkgs

--- a/profiles/min/default.nix
+++ b/profiles/min/default.nix
@@ -16,7 +16,7 @@ in (import ../base/default.nix) ++ (import ../mgmt/default.nix) ++ [
     pkgs.apacheHttpd
     pkgs_1809.mailcatcher
     pkgs.memcached
-    bkpkgs.mysql55
+    bkpkgs.mysql56
     pkgs.redis
     bkpkgs.transifexClient
 


### PR DESCRIPTION
It would be nice to deprecate mysql55. Having a mysql56 package available would make that easier.

NOTE: Still waiting on some test builds to finish. Should backport to `master` after testing+merging into `master-loco`.